### PR TITLE
feat(LocSim): Add Altitude Simulation

### DIFF
--- a/Geranium/LocSim/LocSimView.swift
+++ b/Geranium/LocSim/LocSimView.swift
@@ -150,7 +150,7 @@ struct LocSimView: View {
         self.lat = wgsCoordinate.latitude
         self.long = wgsCoordinate.longitude
         
-        let location = CLLocation(coordinate: wgsCoordinate, altitude: altitude, horizontalAccuracy: 5, verticalAccuracy: 5)
+        let location = CLLocation(coordinate: wgsCoordinate, altitude: altitude,horizontalAccuracy:5,verticalAccuracy: 5,timestamp: Date())
         LocSimManager.startLocSim(location: location)
         
         AlertKitAPI.present(

--- a/Geranium/LocSim/LocSimView.swift
+++ b/Geranium/LocSim/LocSimView.swift
@@ -95,7 +95,7 @@ struct LocSimView: View {
                         }
                     }
                 }) {
-                    Image(systemName: "waveform.path.ecg")
+                    Image(systemName: "mountain.2.fill")
                         .resizable()
                         .aspectRatio(contentMode: .fit)
                         .frame(width: 24, height: 24)
@@ -145,18 +145,14 @@ struct LocSimView: View {
     }
     
     private func startSimulation(at gcjCoordinate: CLLocationCoordinate2D, altitude: Double) {
-        // Convert coordinate from GCJ-02 to WGS-84
         let wgsCoordinate = CoordTransform.gcj02ToWgs84(gcjCoordinate)
         
-        // Update the state variables for any UI that might display them
         self.lat = wgsCoordinate.latitude
         self.long = wgsCoordinate.longitude
         
-        // Start the simulation with the corrected WGS-84 coordinate, including altitude
-        let location = CLLocation(coordinate: wgsCoordinate, altitude: altitude, horizontalAccuracy: 5, verticalAccuracy: 5, timestamp: Date())
+        let location = CLLocation(coordinate: wgsCoordinate, altitude: altitude, horizontalAccuracy: 5, verticalAccuracy: 5)
         LocSimManager.startLocSim(location: location)
         
-        // Show success alert
         AlertKitAPI.present(
             title: "Started!",
             icon: .done,


### PR DESCRIPTION
This PR introduces the ability to simulate altitude in LocSim.

-   Adds a new button to the toolbar in `LocSimView` to set a custom altitude in meters.
![IMG_C8CBDF3FB28B-1](https://github.com/user-attachments/assets/d18eb5a2-a6e4-465e-8301-96fb6710e4c6)

## Initial altitude
<img width="750" height="1334" alt="IMG_0063" src="https://github.com/user-attachments/assets/c4b8e61f-6f81-452b-b291-cd5f3253fe02" />

## Modified altitude
The entered altitude value will only be temporarily stored and will take effect together with simulated positioning. If no altitude is set, the default value is 0.

<img width="750" height="1334" alt="IMG_0064" src="https://github.com/user-attachments/assets/6b9a5089-acfc-499e-a632-2cb70f290bde" />


<img width="750" height="1334" alt="IMG_0065" src="https://github.com/user-attachments/assets/b1658a54-9ceb-4959-8932-afa97f4e72a4" />

Closes  #52